### PR TITLE
consume uid2-shared 1.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <vertx.version>3.9.4</vertx.version>
     <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
     <micrometer.version>1.1.0</micrometer.version>
-    <uid2-shared.version>1.12.0</uid2-shared.version>
+    <uid2-shared.version>1.18.0</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/src/main/java/com/uid2/optout/Main.java
+++ b/src/main/java/com/uid2/optout/Main.java
@@ -13,6 +13,8 @@ import com.uid2.shared.health.HealthManager;
 import com.uid2.shared.jmx.AdminApi;
 import com.uid2.shared.optout.OptOutCloudSync;
 import com.uid2.shared.optout.OptOutUtils;
+import com.uid2.shared.store.CloudPath;
+import com.uid2.shared.store.scope.GlobalScope;
 import com.uid2.shared.vertx.CloudSyncVerticle;
 import com.uid2.shared.vertx.RotatingStoreVerticle;
 import com.uid2.shared.vertx.VertxUtils;
@@ -132,7 +134,10 @@ public class Main {
         }
 
         String operatorsMdPath = this.config.getString(Const.Config.OperatorsMetadataPathProp);
-        this.operatorKeyProvider = new RotatingOperatorKeyProvider(this.fsOperatorKeyConfig, contentStorage, operatorsMdPath);
+        this.operatorKeyProvider = new RotatingOperatorKeyProvider(
+                this.fsOperatorKeyConfig,
+                contentStorage,
+                new GlobalScope(new CloudPath(operatorsMdPath)));
         if (useStorageMock) {
             this.operatorKeyProvider.loadContent(this.operatorKeyProvider.getMetadata());
         }

--- a/src/main/java/com/uid2/optout/vertx/PartnerConfigMonitor.java
+++ b/src/main/java/com/uid2/optout/vertx/PartnerConfigMonitor.java
@@ -5,7 +5,7 @@ import com.uid2.optout.partner.EndpointConfig;
 import com.uid2.optout.partner.PartnersConfig;
 import com.uid2.shared.Utils;
 import com.uid2.shared.cloud.ICloudStorage;
-import com.uid2.shared.store.IMetadataVersionedStore;
+import com.uid2.shared.store.reader.IMetadataVersionedStore;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;

--- a/src/main/java/com/uid2/optout/vertx/PartnerConfigMonitorV2.java
+++ b/src/main/java/com/uid2/optout/vertx/PartnerConfigMonitorV2.java
@@ -6,7 +6,7 @@ import com.uid2.optout.partner.PartnersConfig;
 import com.uid2.shared.Utils;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.cloud.ICloudStorage;
-import com.uid2.shared.store.IMetadataVersionedStore;
+import com.uid2.shared.store.reader.IMetadataVersionedStore;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;


### PR DESCRIPTION
Consume uid2-shared 1.18.0 so
- attestation token supports AES-256-GCM (from only AES-256-CBC) decryption
- consume new storage APIs