### PR TITLE
upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin@sha256:d19c17f59e768549cd3d26f577be73b5e26e652dd66210d91a6738a355aa1dfe
 
 WORKDIR /app
 EXPOSE 8088

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-optout</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
     <name>uid2-optout</name>
     <url>https://github.com/IABTechLab/uid2-optout</url>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <vertx.version>4.3.8</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
-        <uid2-shared.version>2.1.0</uid2-shared.version>
+        <uid2-shared.version>2.3.10-7b7a07fbe9</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-optout</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <name>uid2-optout</name>
     <url>https://github.com/IABTechLab/uid2-optout</url>


### PR DESCRIPTION
**Changes**
- change base image to: eclipse-temurin:11.0.18_10-jre-alpine
- consume uid2-shared 2.3.10-7b7a07fbe9 where there is an upgrade of jackson-databind vuln fix
- bump version by two to avoid deployment pipeline conflict