### PR TITLE
Update shared to get new file event for all workers instead of just one each time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <vertx.version>4.5.3</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
-        <uid2-shared.version>7.1.0-8e67b3a537</uid2-shared.version>
+        <uid2-shared.version>7.5.0-ad06501882</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
 

--- a/src/main/java/com/uid2/optout/Main.java
+++ b/src/main/java/com/uid2/optout/Main.java
@@ -6,7 +6,7 @@ import com.uid2.optout.vertx.PartnerConfigMonitor;
 import com.uid2.optout.vertx.PartnerConfigMonitorV2;
 import com.uid2.shared.ApplicationVersion;
 import com.uid2.shared.Utils;
-import com.uid2.shared.attest.AttestationTokenRetriever;
+import com.uid2.shared.attest.AttestationResponseHandler;
 import com.uid2.shared.attest.NoAttestationProvider;
 import com.uid2.shared.attest.UidCoreClient;
 import com.uid2.shared.auth.RotatingOperatorKeyProvider;
@@ -121,7 +121,7 @@ public class Main {
             if (coreApiToken == null || coreApiToken.isBlank()) {
                 LOGGER.warn("Core Attest URL set, but the API Token is not set");
             }
-            var tokenRetriever = new AttestationTokenRetriever(vertx, coreAttestUrl, coreApiToken, appVersion, new NoAttestationProvider(), null, CloudUtils.defaultProxy);
+            var tokenRetriever = new AttestationResponseHandler(vertx, coreAttestUrl, coreApiToken, appVersion, new NoAttestationProvider(), null, CloudUtils.defaultProxy);
             UidCoreClient uidCoreClient = UidCoreClient.createNoAttest(coreApiToken, tokenRetriever);
             if (useStorageMock) uidCoreClient.setAllowContentFromLocalFileSystem(true);
             this.fsOperatorKeyConfig = uidCoreClient;


### PR DESCRIPTION
Update shared to 7.5.0 to get the changes to the updated event. This means all workers get notified of every new available file.