### PR TITLE
Optout delta sending fixes

### DIFF
--- a/src/main/java/com/uid2/optout/partner/OptOutPartnerEndpoint.java
+++ b/src/main/java/com/uid2/optout/partner/OptOutPartnerEndpoint.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
+import java.time.Duration;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -77,7 +78,7 @@ public class OptOutPartnerEndpoint implements IOptOutPartnerEndpoint {
 
                 LOGGER.info("replaying optout " + config.url() + " - advertising_id: " + Utils.maskPii(entry.advertisingId) + ", epoch: " + entry.timestamp);
 
-                return builder.build();
+                return builder.timeout(Duration.ofSeconds(30)).build();
             },
             resp -> {
                 if (resp == null) {

--- a/src/main/java/com/uid2/optout/web/RetryingWebClient.java
+++ b/src/main/java/com/uid2/optout/web/RetryingWebClient.java
@@ -1,5 +1,6 @@
 package com.uid2.optout.web;
 
+import com.google.common.base.Stopwatch;
 import io.netty.handler.codec.http.HttpMethod;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -10,7 +11,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.BiFunction;
 
@@ -34,15 +37,25 @@ public class RetryingWebClient {
     }
 
     public Future<Void> send(BiFunction<URI, HttpMethod, HttpRequest> requestCreator, Function<HttpResponse, Boolean> responseValidator) {
-        return this.send(requestCreator, responseValidator, 0);
+        final UUID requestId = UUID.randomUUID();
+        return this.send(requestCreator, responseValidator, 0, requestId)
+                .onFailure(ex -> LOGGER.error("requestId={} Request to {} failed", requestId, uri, ex));
     }
 
-    public Future<Void> send(BiFunction<URI, HttpMethod, HttpRequest> requestCreator, Function<HttpResponse, Boolean> responseValidator, int currentRetries) {
+    public Future<Void> send(BiFunction<URI, HttpMethod, HttpRequest> requestCreator, Function<HttpResponse, Boolean> responseValidator, int currentRetries, UUID requestId) {
         HttpRequest request = requestCreator.apply(this.uri, this.method);
+
+        LOGGER.info("requestId={} Sending request to {}, currentRetries={}", requestId, uri, currentRetries);
+
+        final Stopwatch sw = Stopwatch.createStarted();
 
         final CompletableFuture<HttpResponse<Void>> asyncResponse = this.httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding());
 
         return Future.fromCompletionStage(asyncResponse, vertx.getOrCreateContext()).compose(response -> {
+            sw.stop();
+
+            LOGGER.info("requestId={} Request to {} completed in {}ms, currentRetries={}, status={}, version={}", requestId, uri, sw.elapsed(TimeUnit.MILLISECONDS), currentRetries, response.statusCode(), response.version());
+
             Boolean responseOK = responseValidator.apply(response);
             if (responseOK == null) {
                 return Future.failedFuture(new RuntimeException("Response validator returned null"));
@@ -53,16 +66,16 @@ public class RetryingWebClient {
             }
 
             if (currentRetries < this.retryCount) {
-                LOGGER.error("failed sending to " + uri + ", currentRetries: " + currentRetries + ", backing off before retrying");
+                LOGGER.error("requestId={} failed sending to {}, currentRetries={}, backing off for {}ms before retrying", requestId, uri, currentRetries, this.retryBackoffMs);
                 if (this.retryBackoffMs > 0) {
                     return vertx.timer(this.retryBackoffMs)
-                            .compose(v -> send(requestCreator, responseValidator, currentRetries + 1));
+                            .compose(v -> send(requestCreator, responseValidator, currentRetries + 1, requestId));
                 } else {
-                    return send(requestCreator, responseValidator, currentRetries + 1);
+                    return send(requestCreator, responseValidator, currentRetries + 1, requestId);
                 }
             }
 
-            LOGGER.error("retry count exceeded for sending to " + this.uri);
+            LOGGER.error("requestId={} retry count exceeded for sending to {}", requestId, this.uri);
             return Future.failedFuture(new TooManyRetriesException(currentRetries));
         });
     }


### PR DESCRIPTION
- Add 30 second timeout to HTTP requests.
- Re-use gauge counters across Verticle instances.
- Not a fix, but rewrite `RetryingWebClient.send` to compose futures instead of manually dealing with promises.