### PR TITLE
sch-UID2-4560 add gauge for number of processing request threads

### DIFF
--- a/src/main/java/com/uid2/optout/Main.java
+++ b/src/main/java/com/uid2/optout/Main.java
@@ -240,6 +240,7 @@ public class Main {
 
     public void run(String[] args) throws IOException {
         this.createAppStatusMetric();
+        this.createServiceInstancesMetric();
 
         List<Future> futs = new ArrayList<>();
 
@@ -397,6 +398,12 @@ public class Main {
         Gauge.builder("app.status", () -> 1)
             .description("application version and status")
             .tag("version", version)
+            .register(Metrics.globalRegistry);
+    }
+
+    private void createServiceInstancesMetric() {
+        Gauge.builder("uid2.optout.vertx_service_instances", () -> config.getInteger("service_instances"))
+            .description("gauge for number of request processing threads")
             .register(Metrics.globalRegistry);
     }
 

--- a/src/main/java/com/uid2/optout/Main.java
+++ b/src/main/java/com/uid2/optout/Main.java
@@ -240,7 +240,8 @@ public class Main {
 
     public void run(String[] args) throws IOException {
         this.createAppStatusMetric();
-        this.createServiceInstancesMetric();
+        this.createVertxInstancesMetric();
+        this.createVertxEventLoopsMetric();
 
         List<Future> futs = new ArrayList<>();
 
@@ -401,9 +402,15 @@ public class Main {
             .register(Metrics.globalRegistry);
     }
 
-    private void createServiceInstancesMetric() {
+    private void createVertxInstancesMetric() {
         Gauge.builder("uid2.optout.vertx_service_instances", () -> config.getInteger("service_instances"))
-            .description("gauge for number of request processing threads")
+            .description("gauge for number of vertx service instances requested")
+            .register(Metrics.globalRegistry);
+    }
+
+    private void createVertxEventLoopsMetric() {
+        Gauge.builder("uid2.optout.vertx_event_loop_threads", () -> VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE)
+            .description("gauge for number of vertx event loop threads")
             .register(Metrics.globalRegistry);
     }
 


### PR DESCRIPTION
Added gauge for number of vertx instances and event loop threads in Optout. This will allow us to allocate the appropriate number of CPUs to reduce latency. 