### PR TITLE
Remove EXTRA_CONFIG build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ EXPOSE 8088
 ARG JAR_NAME=uid2-optout
 ARG JAR_VERSION=1.0.0-SNAPSHOT
 ARG IMAGE_VERSION=1.0.0.unknownhash
-ARG EXTRA_CONFIG
 ENV JAR_NAME=${JAR_NAME}
 ENV JAR_VERSION=${JAR_VERSION}
 ENV IMAGE_VERSION=${IMAGE_VERSION}
@@ -15,7 +14,7 @@ ENV IMAGE_VERSION=${IMAGE_VERSION}
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-jar-with-dependencies.jar /app/${JAR_NAME}-${JAR_VERSION}.jar
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
 COPY ./run_tool.sh /app
-COPY ./conf/default-config.json ${EXTRA_CONFIG} /app/conf/
+COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
 RUN addgroup --gid 1100 uidusers && adduser -D -G uidusers --uid 1100 uid2-optout && mkdir -p /opt/uid2 && chmod 755 -R /opt/uid2 && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads


### PR DESCRIPTION
This unused arg causes the entire build context to be copied to /app/conf, including 1.7G of Trivy cache files.