### PR TITLE
upgrade vertx from 4.5.13 to 4.5.18 due to CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.1.0</micrometer.version>
-        <uid2-shared.version>10.7.11</uid2-shared.version>
+        <uid2-shared.version>10.9.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <junit-vintage.version>5.10.1</junit-vintage.version>


### PR DESCRIPTION
also upgrade uid2-shared to 10.9.0 which has same vertx upgrade.