### PR TITLE
xuy-UID2-6055-upgrade-awsjavasdk-v2-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-optout</artifactId>
-    <version>4.3.8-alpha-93-SNAPSHOT</version>
+    <version>4.3.9-alpha-94-SNAPSHOT</version>
 
     <name>uid2-optout</name>
     <url>https://github.com/IABTechLab/uid2-optout</url>


### PR DESCRIPTION
upgrade to uid2-shared lib 11.1.5, which contains fix for presigner. 
Before the fix, the presigner append bucket name in host, and cause operator unknown host exception.