### PR TITLE
UID2-6929: CVE-2026-40200 upgrade musl/musl-utils to 1.2.5-r23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY ./run_tool.sh /app
 COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
-RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 && addgroup --gid 1100 uidusers && adduser -D -G uidusers --uid 1100 uid2-optout && mkdir -p /opt/uid2 && chmod 755 -R /opt/uid2 && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
+RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils && addgroup --gid 1100 uidusers && adduser -D -G uidusers --uid 1100 uid2-optout && mkdir -p /opt/uid2 && chmod 755 -R /opt/uid2 && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
 USER uid2-optout
 
 CMD java \


### PR DESCRIPTION
## Summary

CVE-2026-40200 (HIGH): musl libc arbitrary code execution and denial of service vulnerability in `musl`/`musl-utils` 1.2.5-r21. Fixed in 1.2.5-r23.

Adds `musl musl-utils` to the existing `apk upgrade` in the Dockerfile so the patched packages are installed at image build time.