### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -50,6 +50,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit
 
   e2e-test:


### PR DESCRIPTION
- Use `ci-auto-merge` environment for `Release UID2 Optout Image` workflow that requires PR to be automatically merged
- This is required to bypass the PR Approval ruleset

Related:
- https://github.com/IABTechLab/uid2-shared-actions/pull/219