### PR TITLE
docs: clarify <tag> in attestation verify command (UID2-6764)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ Every non-snapshot image published by this repo's release workflow ships with a 
 To verify an image, install [`gh`](https://cli.github.com/) (≥ 2.49) and run:
 
 ```bash
-gh attestation verify \
-  oci://ghcr.io/iabtechlab/uid2-optout:<tag> \
-  --owner IABTechLab \
-  --signer-repo IABTechLab/uid2-shared-actions
+gh attestation verify oci://ghcr.io/iabtechlab/uid2-optout:<tag> --owner IABTechLab --signer-repo IABTechLab/uid2-shared-actions
 ```
+
+`<tag>` refers to the **Docker image tag** — bare semantic version, no `v` prefix (e.g. `4.9.64`). Note that the corresponding GitHub release and git tag for the same build are named with a `v` (e.g. `v4.9.64`); the registry tag drops it by OCI convention.
+
+**Where to find a tag:**
+
+- **GitHub Packages** for this repo — [`uid2-optout` package](https://github.com/IABTechLab/uid2-optout/pkgs/container/uid2-optout) lists every published image tag and its digest.
+- Or take a [release](https://github.com/IABTechLab/uid2-optout/releases) name (e.g. `v4.9.64`) and drop the leading `v`.
+- To pin to an exact manifest instead of a mutable tag, use the digest form: `oci://ghcr.io/iabtechlab/uid2-optout@sha256:<digest>` (visible on the Packages page, or via `gh api /orgs/IABTechLab/packages/container/uid2-optout/versions`).
 
 A successful run prints `✓ Verification succeeded!` followed by the SLSA provenance fields — including `sourceRepositoryDigest` (the source commit), `workflow.path` (the signing workflow), and the runner identity.
 


### PR DESCRIPTION
## Summary

- Clarifies that `<tag>` in the `gh attestation verify` command is the **Docker image tag** (bare semantic version, no `v` prefix — e.g. `4.9.64`), not the git/release tag (`v4.9.64`).
- Adds a "Where to find a tag" list pointing at GitHub Packages, the release-name shortcut, and digest pinning for exact-manifest verification.
- Collapses the example command onto a single line so it copy-pastes cleanly on Windows shells as well as macOS/Linux (no `\` line-continuation).

Follow-up to UID2-6764 (artifact signing and provenance rollout) — wording-only.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the section reads cleanly.
- [ ] Confirm the example command, copy-pasted as-is, runs against a real tag substituted in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)