### PR TITLE
UID2-7335: bump base image to sha256:3f08b138 (retire explicit libexpat upgrade)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
-FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 
 WORKDIR /app
 EXPOSE 8088
@@ -17,7 +17,7 @@ COPY ./run_tool.sh /app
 COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
-RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils gnutls libexpat && addgroup --gid 1100 uidusers && adduser -D -G uidusers --uid 1100 uid2-optout && mkdir -p /opt/uid2 && chmod 755 -R /opt/uid2 && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
+RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils gnutls && addgroup --gid 1100 uidusers && adduser -D -G uidusers --uid 1100 uid2-optout && mkdir -p /opt/uid2 && chmod 755 -R /opt/uid2 && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads
 USER uid2-optout
 
 CMD java \


### PR DESCRIPTION
## What
Bumps the `eclipse-temurin` base image from the prior pin to `sha256:3f08b138…` (the 2026-06-22 rebuild of `21-jre-alpine-3.23`) and removes the explicit `apk add --upgrade libexpat` added in the previous fix.

## Why
The new base image ships **libexpat 2.8.1-r0**, which resolves **CVE-2026-45186** (HIGH) at the base layer. The explicit per-package upgrade is therefore redundant and is dropped — matching this repo's convention of removing `--upgrade` lines once the base image carries the fix (cf. the earlier gnutls cleanup).

Verified by pulling the new digest: `libexpat-2.8.1-r0` is installed.
