### PR TITLE
[Security] UID2-7569/7570/7571-7574: Upgrade jackson to 2.21.4 and Netty to 4.1.136.Final

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -15,14 +15,6 @@ GHSA-72hv-8253-57qq exp:2026-09-01
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
 
-# jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
-# jackson-databind is pulled in transitively via uid2-shared; the version fix is tracked in
-# uid2-shared (https://github.com/IABTechLab/uid2-shared/pull/631) and will flow here on the
-# next uid2-shared release. Suppressing in the interim.
-# See: UID2-7364
-CVE-2026-54512 exp:2026-07-25
-CVE-2026-54513 exp:2026-07-25
-
 # CVE-2026-2100 — p11-kit NULL dereference via C_DeriveKey in the Alpine base image.
 # uid2-optout is a pure Java service; the JVM uses JSSE for TLS and the bundled Java cacerts keystore for trust — it does
 # not load the native p11-kit PKCS#11 module loader and never calls C_DeriveKey, so the

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
         <micrometer.version>1.1.0</micrometer.version>
         <uid2-shared.version>11.6.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
+        <jackson.version>2.21.4</jackson.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <junit-vintage.version>5.10.1</junit-vintage.version>
     </properties>
@@ -33,6 +34,14 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
+            <!-- Force jackson to a fixed version to resolve CVE-2026-54512, CVE-2026-54513 (UID2-7569, UID2-7570). -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
## Summary
Resolves HIGH-severity dependency vulnerabilities flagged by the scheduled Trivy scan.

| Dependency | CVEs | Fix |
|---|---|---|
| `jackson-databind` | CVE-2026-54512 (RCE), CVE-2026-54513 (bypass) | jackson-bom `2.21.4` in `dependencyManagement` |
| `io.netty` | CVE-2026-55831, CVE-2026-55833, CVE-2026-56745, CVE-2026-59901 | `netty.version` → `4.1.136.Final` |

Reachable production dependencies → real upgrade, not suppression.

## Tickets
UID2-7569, UID2-7570 (jackson); UID2-7571–7574 (Netty)

## Testing
Build + unit tests run in CI (no local Maven available).