### PR TITLE
UID2-7760: bump eclipse-temurin digest to fix sqlite-libs CVE-2026-11822/11824

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -28,9 +28,12 @@ CVE-2026-2100 exp:2026-09-01
 # JAXP/Xerces implementation, not the native libexpat C library, and there are no JNI bindings or
 # native deps that call into libexpat, so the crafted-XML attack path is not reachable. Fixed in
 # Alpine v3.23 libexpat >= 2.8.2-r0; the pinned eclipse-temurin base image has not yet been rebuilt with it.
+# Renewed rather than removed: Alpine's package index now shows libexpat 2.8.3-r0, above the fix
+# threshold, but that's not yet confirmed inside our pinned image digest. See UID2-7763 for the
+# base-image-bump investigation.
 # See: UID2-7456
-CVE-2026-56131 exp:2026-08-09
-CVE-2026-56407 exp:2026-08-09
+CVE-2026-56131 exp:2026-09-27
+CVE-2026-56407 exp:2026-09-27
 # CVE-2026-56408 — libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-
 # alpine-3.23) (HIGH).
 # Not exploitable here: Same alpine base; libexpat not explicitly installed. No expat/JNI refs;
@@ -40,9 +43,9 @@ CVE-2026-56408 exp:2026-11-11
 
 # jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
 # GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
-# jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
-# (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
-GHSA-r7wm-3cxj-wff9 exp:2026-08-23
+# jackson-core's non-blocking/async parser. Note: uid2-shared PR #631 (previously cited here as
+# "in flight") was reverted in #633 — not a fix for this GHSA. See: UID2-7557 (predecessor UID2-6670)
+GHSA-r7wm-3cxj-wff9 exp:2026-09-27
 
 # CVE-2026-40984 — io.micrometer:micrometer-core (transitive via micrometer-registry-
 # prometheus/-jmx); micrometer-jetty11/12 not present (HIGH).

--- a/.trivyignore
+++ b/.trivyignore
@@ -15,32 +15,6 @@ GHSA-72hv-8253-57qq exp:2026-09-01
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
 
-# CVE-2026-2100 — p11-kit NULL dereference via C_DeriveKey in the Alpine base image.
-# uid2-optout is a pure Java service; the JVM uses JSSE for TLS and the bundled Java cacerts keystore for trust — it does
-# not load the native p11-kit PKCS#11 module loader and never calls C_DeriveKey, so the
-# vulnerable code path is not reachable. Fixed in Alpine v3.23 >= 0.26.2-r0 but the pinned
-# eclipse-temurin base image has not yet been rebuilt with it.
-# See: UID2-7376
-CVE-2026-2100 exp:2026-09-01
-
-# CVE-2026-56131 / CVE-2026-56407 / CVE-2026-56408 — libexpat stack exhaustion / integer overflows
-# in the Alpine base image. uid2-optout is a pure Java service; the JVM parses XML via the built-in
-# JAXP/Xerces implementation, not the native libexpat C library, and there are no JNI bindings or
-# native deps that call into libexpat, so the crafted-XML attack path is not reachable. Fixed in
-# Alpine v3.23 libexpat >= 2.8.2-r0; the pinned eclipse-temurin base image has not yet been rebuilt with it.
-# Renewed rather than removed: Alpine's package index now shows libexpat 2.8.3-r0, above the fix
-# threshold, but that's not yet confirmed inside our pinned image digest. See UID2-7763 for the
-# base-image-bump investigation.
-# See: UID2-7456
-CVE-2026-56131 exp:2026-09-27
-CVE-2026-56407 exp:2026-09-27
-# CVE-2026-56408 — libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-
-# alpine-3.23) (HIGH).
-# Not exploitable here: Same alpine base; libexpat not explicitly installed. No expat/JNI refs;
-# JVM parses config/logback XML, not libexpat.
-# See: UID2-7656
-CVE-2026-56408 exp:2026-11-11
-
 # jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
 # GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
 # jackson-core's non-blocking/async parser. Note: uid2-shared PR #631 (previously cited here as
@@ -55,11 +29,3 @@ GHSA-r7wm-3cxj-wff9 exp:2026-09-27
 # See: UID2-7662
 CVE-2026-40984 exp:2026-11-11
 
-# CVE-2026-11822 / CVE-2026-11824 — sqlite-libs (Alpine base image, transitive via
-# eclipse-temurin:21-jre-alpine-3.23) (HIGH). Not exploitable: uid2-optout is a pure Java
-# service with no SQLite/JDBC driver dependency and no JNI bindings; the FTS5 attack path
-# requires an application to invoke SQLite's full-text search engine, which this service
-# never does. Same pattern already confirmed for uid2-admin in UID2-7748.
-# See: UID2-7760
-CVE-2026-11822 exp:2026-09-27
-CVE-2026-11824 exp:2026-09-27

--- a/.trivyignore
+++ b/.trivyignore
@@ -51,3 +51,12 @@ GHSA-r7wm-3cxj-wff9 exp:2026-08-23
 # binder
 # See: UID2-7662
 CVE-2026-40984 exp:2026-11-11
+
+# CVE-2026-11822 / CVE-2026-11824 — sqlite-libs (Alpine base image, transitive via
+# eclipse-temurin:21-jre-alpine-3.23) (HIGH). Not exploitable: uid2-optout is a pure Java
+# service with no SQLite/JDBC driver dependency and no JNI bindings; the FTS5 attack path
+# requires an application to invoke SQLite's full-text search engine, which this service
+# never does. Same pattern already confirmed for uid2-admin in UID2-7748.
+# See: UID2-7760
+CVE-2026-11822 exp:2026-09-27
+CVE-2026-11824 exp:2026-09-27

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
-FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
+FROM eclipse-temurin@sha256:319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
 
 WORKDIR /app
 EXPOSE 8088


### PR DESCRIPTION
## Summary
CVE-2026-11822 and CVE-2026-11824 (HIGH, sqlite-libs) were flagged in the Alpine base image (eclipse-temurin:21-jre-alpine-3.23). Originally suppressed in `.trivyignore` as non-exploitable (uid2-optout has no SQLite/JDBC dependency), but a newer build of the same pinned tag turned out to already ship fixed versions of sqlite-libs (and libexpat, p11-kit) — confirmed by pulling and inspecting the image directly (`apk list -I`), not just trusting the Alpine package index.

This PR bumps the pinned digest to that build instead of continuing to suppress, and removes the now-unnecessary `.trivyignore` entries for CVE-2026-11822/11824, CVE-2026-2100 (p11-kit), and CVE-2026-56131/56407/56408 (libexpat).

Jira: https://thetradedesk.atlassian.net/browse/UID2-7760

## Test plan
- [x] `mvn package` + `docker build` with the new digest, then `trivy image --severity HIGH,CRITICAL` against the built image — 0 findings